### PR TITLE
Quick buttons borders fix & more

### DIFF
--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -193,7 +193,7 @@ define -2 gui.confirm_button_text_xalign = 0.5
 define -2 gui.page_button_borders = Borders(10, 4, 10, 4)
 
 
-define -2 gui.quick_button_text_size = 16
+define -2 gui.quick_button_text_size = 19
 define -2 gui.quick_button_text_idle_color = "#522"
 define -2 gui.quick_button_text_hover_color = "#fcc"
 define -2 gui.quick_button_text_selected_color = gui.accent_color
@@ -407,57 +407,57 @@ init -2 python:
 
 
 
-    if renpy.variant("touch"):
-        
-        gui.quick_button_borders = Borders(60, 14, 60, 0)
+    if renpy.variant("touch"): #Quick buttons borders fix
+
+        gui.quick_button_borders = Borders(30, 7, 30, 0)
 
 
 
     if False:  # TO!DONE: problem: defaults!
-        
-        
+
+
         gui.text_size = 30
         gui.name_text_size = 36
         gui.notify_text_size = 25
         gui.interface_text_size = 36
         gui.button_text_size = 34
         gui.label_text_size = 36
-        
-        
+
+
         gui.textbox_height = 240
         gui.name_xpos = 80
         gui.text_xpos = 90
         gui.text_width = 1100
-        
-        
+
+
         gui.choice_button_width = 1240
-        
+
         gui.navigation_spacing = 20
         gui.pref_button_spacing = 10
-        
+
         gui.history_height = 190
         gui.history_text_width = 690
-        
-        
+
+
         gui.file_slot_cols = 2
         gui.file_slot_rows = 2
-        
-        
+
+
         gui.nvl_height = 170
-        
+
         gui.nvl_name_width = 305
         gui.nvl_name_xpos = 325
-        
+
         gui.nvl_text_width = 915
         gui.nvl_text_xpos = 345
         gui.nvl_text_ypos = 5
-        
+
         gui.nvl_thought_width = 1240
         gui.nvl_thought_xpos = 20
-        
+
         gui.nvl_button_width = 1240
         gui.nvl_button_xpos = 20
-        
-        
+
+
         gui.quick_button_text_size = 20
 # Decompiled by unrpyc: https://github.com/CensoredUsername/unrpyc

--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -409,7 +409,7 @@ init -2 python:
 
     if renpy.variant("touch"): #Quick buttons borders fix
 
-        gui.quick_button_borders = Borders(30, 7, 30, 0)
+        gui.quick_button_borders = Borders(18, 7, 20, 0)
 
 
 

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -460,9 +460,10 @@ init -501 screen navigation():
                     textbutton _("Main Menu") action NullAction()
 
             textbutton _("Settings") action [ShowMenu("preferences"), SensitiveIf(renpy.get_screen("preferences") == None)]
-            
+
             #Added by AlexAzumi
-            textbutton _("Characters") action [ShowMenu("characters"), SensitiveIf(renpy.get_screen("characters") == None)]
+            if persistent.playthrough > 0:
+                textbutton _("Characters") action [ShowMenu("characters"), SensitiveIf(renpy.get_screen("characters") == None)]
 
 
             if renpy.variant("pc"):
@@ -924,26 +925,34 @@ init -501 screen characters() tag menu:
                         xalign 0.5
                         text_size 50
                     null height 10
+
+                    python:
+                        monika_flag = check_if_exist("monika")
+                        natsuki_flag = check_if_exist("natsuki")
+                        sayori_flag = check_if_exist("sayori")
+                        yuri_flag = check_if_exist("yuri")
+
+                    #Buttons cannot be pressed if the character does not exist
                     textbutton "Restore all characters":
                         action [Function(restore_all_characters), Show(screen="dialog", message="All characters have been restored", ok_action=Hide("dialog"))]
                     null height 5
-                    
-                    textbutton "Delete Monika":
-                        action [Function(delete_character, "monika"), Show(screen="dialog", message="Monika has been deleted", ok_action=Hide("dialog"))]
-                    null height 5
-                    
-                    textbutton "Delete Natsuki":
-                        action [Function(delete_character, "natsuki"), Show(screen="dialog", message="Natsuki has been deleted", ok_action=Hide("dialog"))]
-                    null height 5
-                    
-                    textbutton "Delete Sayori":
-                        action [Function(delete_character, "sayori"), Show(screen="dialog", message="Sayori has been deleted", ok_action=Hide("dialog"))]
-                    null height 5
-                    
-                    textbutton "Delete Yuri":
-                        action [Function(delete_character, "yuri"), Show(screen="dialog", message="Yuri has been deleted", ok_action=Hide("dialog"))]
 
-    
+                    textbutton "Delete Monika":
+                        action [Function(delete_character, "monika"), Show(screen="dialog", message="Monika has been deleted", ok_action=Hide("dialog")), SensitiveIf(monika_flag)]
+                    null height 5
+
+                    textbutton "Delete Natsuki":
+                        action [Function(delete_character, "natsuki"), Show(screen="dialog", message="Natsuki has been deleted", ok_action=Hide("dialog")), SensitiveIf(natsuki_flag)]
+                    null height 5
+
+                    textbutton "Delete Sayori":
+                        action [Function(delete_character, "sayori"), Show(screen="dialog", message="Sayori has been deleted", ok_action=Hide("dialog")), SensitiveIf(sayori_flag)]
+                    null height 5
+
+                    textbutton "Delete Yuri":
+                        action [Function(delete_character, "yuri"), Show(screen="dialog", message="Yuri has been deleted", ok_action=Hide("dialog")), SensitiveIf(yuri_flag)]
+
+
 init -501 screen preferences() tag menu:
 
 

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -312,7 +312,7 @@ label ch30_main2:
     m "It kind of freaked me out, how easy it was."
     m "Well, you're playing on Android, so it was actually a bit less difficult..."
     m "I had to go to 'Settings' and find the 'Characters' button..."  # TODOne: monika fix
-    elif renpy.macintosh:
+    if renpy.macintosh:
         m "Well, you're on a Mac, so it was actually a bit more difficult..."
         m "To go into the game directory, you have to right-click the app and click 'Show Package Contents'."
         m "Then, all the files were in the 'Resources' or 'autorun' folder, and I could just do whatever I wanted..."
@@ -802,7 +802,7 @@ label ch30_reload_2:
     m "Maybe you should make a backup of it or something..."
     m "I'm pretty sure you can find it in the folder called [basedir]/characters."
     m "Well, you're playing on Android, so you can just go to 'Settings' and find the 'Characters' button."  # TODOne: monika fix
-    elif renpy.macintosh:
+    if renpy.macintosh:
         m "Since you're on a Mac, you have to right-click the app and select 'Show Package Contents' to find the game folder."
         m "It's in the 'Resources' folder, or 'autorun' folder, or something..."
     m "I'm all that's left here, so I just want to make sure you don't run the risk of losing me..."
@@ -824,7 +824,7 @@ label ch30_reload_4:
     m "Were you making sure my character file was okay for me?"
     m "It's in [basedir]/characters."
     m "Well, you're playing on Android, so you can just go to 'Settings' and find the 'Characters' button."  # TODOne: monika fix
-    elif renpy.macintosh:
+    if renpy.macintosh:
         m "Since you're on a Mac, you have to right-click the app and select 'Show Package Contents' to find the game folder."
         m "It's in the 'Resources' folder, or 'autorun' folder, or something..."
     m "I'm all that's left here, so I just want to make sure you don't run the risk of losing me..."


### PR DESCRIPTION
Quick buttons borders were changed to fit inside the `dialogbox` and `poems`.

The chapter 30 had a syntaxis error in Monika's replicas, on the other hand, some changes were not merged because of me.

> I'm so sorry :(

